### PR TITLE
arm: Add missing include

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/debug.c
+++ b/arch/arm/core/aarch32/cortex_m/debug.c
@@ -10,6 +10,7 @@
  *
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <aarch32/cortex_m/dwt.h>
 


### PR DESCRIPTION
Add missing include to prevent `'EINVAL' undeclared` when using `CONFIG_NULL_POINTER_EXCEPTION_DETECTION_DWT=y`